### PR TITLE
Add support for params attribute

### DIFF
--- a/grails-app/taglib/hungry/wombat/UploadrTagLib.groovy
+++ b/grails-app/taglib/hungry/wombat/UploadrTagLib.groovy
@@ -52,20 +52,23 @@ class UploadrTagLib {
 
 		// define uri
 		if (attrs.get('controller')) {
-		    // got an action attribute?
+			//get parameters if any to pass to the custom controller/action
+                        def params = attrs.containsKey('params') ? attrs.get('params') : []
+		        
+		        // got an action attribute?
 			if (attrs.get('action')) {
 				// got a plugin attribute?
 				if (attrs.get('plugin')) {
-					uri = createLink(plugin: attrs.plugin, controller: attrs.controller, action: attrs.action)
+					uri = createLink(plugin: attrs.plugin, controller: attrs.controller, action: attrs.action, params: params)
 				} else {
-					uri = createLink(controller: attrs.controller, action: attrs.action)
+					uri = createLink(controller: attrs.controller, action: attrs.action, params: params)
 				}
 			} else {
 				// got a plugin attribute?
 				if (attrs.get('plugin')) {
-					uri = createLink(plugin: attrs.plugin, controller: attrs.controller)
+					uri = createLink(plugin: attrs.plugin, controller: attrs.controller, params: params)
 				} else {
-					uri = createLink(controller: attrs.controller)
+					uri = createLink(controller: attrs.controller, params: params)
 				}
 			}
 		} else {


### PR DESCRIPTION
This commit hold changes for the uploadr:add tag.  It adds a params attribute that can be used to pass custom information into a custom controller/action or custom plugin.
